### PR TITLE
Disable V4L2 VP9 decoder for now

### DIFF
--- a/org.sigxcpu.Livi.json
+++ b/org.sigxcpu.Livi.json
@@ -10,7 +10,8 @@
         "--share=network",
         "--socket=pulseaudio",
         "--socket=wayland",
-        "--filesystem=xdg-videos"
+        "--filesystem=xdg-videos",
+        "--env=GST_PLUGIN_FEATURE_RANK=v4l2slvp9dec:0"
     ],
     "cleanup" : [
         "/include",


### PR DESCRIPTION
It currently fails on im8 and rk3399, so disable it. Should be retested once we update to Gst 1.24.

---

See https://github.com/flathub/org.sigxcpu.Livi/pull/6#issuecomment-1902078609