### PR TITLE
Update to 0.1.0 follow-up

### DIFF
--- a/org.sigxcpu.Livi.json
+++ b/org.sigxcpu.Livi.json
@@ -77,8 +77,7 @@
                 {
                     "type": "git",
                     "url": "https://gitlab.freedesktop.org/gstreamer/gstreamer.git",
-                    "branch": "1.24",
-                    "commit": "db6803bd55ae4d0789cc520f8563bd1fc8980eb4",
+                    "commit": "5a80a146f0d8905f5a92dbe58985ab46e5d407fe",
                     "disable-submodules": true
                 }
             ],
@@ -99,7 +98,7 @@
                 {
                     "type" : "git",
                     "url" : "https://gitlab.gnome.org/guidog/livi",
-                    "tage" : "0.1.0",
+                    "tag" : "v0.1.0",
                     "commit" : "2995b99d079b9310d794eaeee8c2e849ed69f31f"
                 }
             ]


### PR DESCRIPTION
 - Fix `tage` typo as well as `0.1.0` -> `v0.1.0`
 - Don't use a branch for Gst. Unfortunately 1.24.1 has not been tagged
   yet, so just update to the latest commit there.
 - Remove network permissions as there's currently no usable UI for it.